### PR TITLE
Update remotetech_Probes.cfg

### DIFF
--- a/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Probes.cfg
+++ b/Gamedata/Bluedog_DB/Compatibility/RemoteTech/remotetech_Probes.cfg
@@ -586,6 +586,8 @@
 {
 
     %MODULE[ModuleSPU] {}
+    
+    !MODULE[ModuleDataTransmitter] {}
 
     %MODULE[ModuleRTAntennaPassive]
     {


### PR DESCRIPTION
Good Evening - I added a line for the OGO-Core to remove the ModuleDataTransmitter as it is in the original config for the probe core. Thank you for your time